### PR TITLE
add podspec file

### DIFF
--- a/TinyCSV.podspec
+++ b/TinyCSV.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name                 = "TinyCSV"
+  s.version              = "0.5.1"
+  s.summary              = "A tiny Swift CSV decoder/encoder library"
+  s.description          = <<-DESC
+    A tiny Swift CSV decoder/encoder library, conforming to RFC 4180 as closely as possible
+  DESC
+  s.homepage             = "https://github.com/dagronf"
+  s.license              = { :type => "MIT", :file => "LICENSE" }
+  s.author               = { "Darren Ford" => "dford_au-reg@yahoo.com" }
+  s.source               = { :git => "https://github.com/dagronf/TinyCSV.git", :tag => s.version.to_s }
+  s.platforms            = { :ios => "12.0", :tvos => "12.0", :osx => "10.13", :watchos => "4.0" }
+  s.source_files         = 'Sources/TinyCSV/**/*.swift'
+  s.swift_versions       = ['5.4', '5.5', '5.6', '5.7']
+end


### PR DESCRIPTION
Updating podspec file to publish **TinyCSV** on Cocoapods dependency manager.
This process will release the module on the Cocoapods public spec repo.

This will release the version 0.5.1 of **TinyCSV**. However this is not the latest (0.6.0) version.

This module is used as a dependency in the module [**SwiftSubtitles**](https://github.com/dagronf/SwiftSubtitles).
This module needs to be made available in order for **SwiftSubtitles** to pass validation.
The reason why it's targeting 0.5.1 instead of 0.6.0 is because  **SwiftSubtitles** depends on the former.

Validation checked and passing.
Validating with command: `pod spec lint TinyCSV.podspec --verbose` at the root of the project directory.